### PR TITLE
Add firmware 13.40 porting scaffold on fw-13.40-research branch

### DIFF
--- a/include/fw_1340_porting.h
+++ b/include/fw_1340_porting.h
@@ -1,0 +1,11 @@
+#ifndef FW_1340_PORTING_H
+#define FW_1340_PORTING_H
+
+#include <stdint.h>
+
+#define FW_1340_VERSION 0x1340u
+
+int is_fw_1340_target(uint16_t fw);
+void notify_fw_1340_porting_status(uint16_t fw);
+
+#endif

--- a/source/fw_1340_porting.c
+++ b/source/fw_1340_porting.c
@@ -1,0 +1,14 @@
+#include "fw_1340_porting.h"
+#include "utils.h"
+
+int is_fw_1340_target(uint16_t fw) { return fw == FW_1340_VERSION; }
+
+void notify_fw_1340_porting_status(uint16_t fw) {
+  if (!is_fw_1340_target(fw))
+    return;
+
+  notify("Firmware 13.40 (26.04-13.40.00) is a porting target on this fork.\n"
+         "Public kernel exploit, HV defeat offsets, and resume shellcode\n"
+         "offsets are not available yet — booting Linux is not possible.\n"
+         "Track branch fw-13.40-research for future updates.\n");
+}

--- a/source/main.c
+++ b/source/main.c
@@ -1,3 +1,4 @@
+#include "fw_1340_porting.h"
 #include "hv_defeat_0304.h"
 #include "hv_defeat_0506.h"
 #include "loader.h"
@@ -31,6 +32,7 @@ int main(void) {
     if (hv_defeat_0506(shellcode_kernel, shellcode_kernel_len))
       goto err;
   } else {
+    notify_fw_1340_porting_status(fw);
     goto err;
   }
 

--- a/source/utils.c
+++ b/source/utils.c
@@ -1,4 +1,5 @@
 #include "utils.h"
+#include "fw_1340_porting.h"
 #include "linux.h"
 #include "offsets.h"
 #include <stdio.h>
@@ -77,6 +78,7 @@ int set_offsets(void) {
     env_offset = off_0602;
     break;
   default:
+    notify_fw_1340_porting_status(fw);
     return -1;
   }
   return 0;


### PR DESCRIPTION
Detect PS5 system software 13.40 (26.04-13.40.00) and emit a clear on-console message that kernel/HV offsets and exploits are not yet available. This branch tracks research toward a future port without shipping placeholder offsets that could destabilize the console.